### PR TITLE
Add linting setup and update type definitions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "env": {"node": true, "es2020": true}
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "npm run prepare-deploy && vite build && cp -r public/* dist/",
     "start": "node server/prod-server.js",
     "check": "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint \"{server,client,shared}/**/*.{ts,tsx}\" --max-warnings=0",
     "db:push": "drizzle-kit push",
     "deploy": "npm run build && npm run start",
     "prepare-deploy": "node complete-deployment-fix.cjs"
@@ -120,7 +122,16 @@
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.4",
     "typescript": "5.6.3",
-    "vite": "^6.3.4"
+    "vite": "^6.3.4",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0"
+  },
+  "eslintConfig": {
+    "parser": "@typescript-eslint/parser",
+    "plugins": ["@typescript-eslint"],
+    "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+    "env": { "node": true, "es2020": true }
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -75,7 +75,7 @@ export class DatabaseStorage implements IStorage {
         await db.update(toolConfigs)
           .set({
             config: {
-              ...existingTool.config,
+              ...(existingTool.config as Record<string, any>),
               ...status,
               lastUpdated: new Date().toISOString()
             }
@@ -116,7 +116,8 @@ export class DatabaseStorage implements IStorage {
       transport: 'http',
       wsEnabled: true,
       environment: process.env.NODE_ENV || 'development',
-      features
+      features,
+      activeTools: [],
     };
   }
   

--- a/server/storage/index.ts
+++ b/server/storage/index.ts
@@ -28,8 +28,7 @@ export interface IStorage {
   
   // Tool configuration operations
   getToolConfig(id: number): Promise<ToolConfig | undefined>;
-  getToolConfigByUserAndType(userId: number, toolType: string): Promise<ToolConfig | undefined>;
-  getAllToolConfigs(userId: number): Promise<ToolConfig[]>;
+  getAllToolConfigs(): Promise<ToolConfig[]>;
   createToolConfig(config: InsertToolConfig): Promise<ToolConfig>;
   updateToolConfig(id: number, config: Partial<ToolConfig>): Promise<ToolConfig | undefined>;
   
@@ -130,12 +129,9 @@ export class DatabaseStorage implements IStorage {
     return this.toolRepo.getToolConfig(id);
   }
   
-  getToolConfigByUserAndType(userId: number, toolType: string) {
-    return this.toolRepo.getToolConfigByUserAndType(userId, toolType);
-  }
   
-  getAllToolConfigs(userId: number) {
-    return this.toolRepo.getAllToolConfigs(userId);
+  getAllToolConfigs() {
+    return this.toolRepo.getAllToolConfigs();
   }
   
   createToolConfig(config: InsertToolConfig) {

--- a/server/storage/status-repository.ts
+++ b/server/storage/status-repository.ts
@@ -18,7 +18,10 @@ export class StatusRepository {
       version: "0.1.0-alpha",
       uptime: 0,
       transport: "STDIO",
-      activeTools: []
+      activeTools: [],
+      wsEnabled: true,
+      environment: process.env.NODE_ENV || "development",
+      features: {},
     };
     
     // Initialize default tool statuses
@@ -86,9 +89,10 @@ export class StatusRepository {
    * Update tool status
    */
   async updateToolStatus(toolName: string, status: Partial<ToolStatus>): Promise<void> {
-    const currentStatus = this.toolStatus.get(toolName) || { 
+    const currentStatus = this.toolStatus.get(toolName) || {
       name: toolName,
-      available: false
+      available: false,
+      latency: 0,
     };
     
     this.toolStatus.set(toolName, {

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,7 +1,7 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
+import { createServer as createViteServer, createLogger, type ServerOptions } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
@@ -20,7 +20,7 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
-  const serverOptions = {
+  const serverOptions: ServerOptions = {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     host: '0.0.0.0',
     strictPort: true,
     hmr: {
-      clientPort: null,
+      clientPort: 443,
       port: 443,
       host: '',
       protocol: 'wss'


### PR DESCRIPTION
## Summary
- add ESLint config and lint/typecheck npm scripts
- expand database schema types for users and system status
- update Vite server options typing
- adjust storage implementations for new types

## Testing
- `npm run typecheck` *(fails: Property 'upsertUser' does not exist on type 'DatabaseStorage', etc.)*
